### PR TITLE
Use route + destination as key for CTA arrival dictionary

### DIFF
--- a/chicagoCTA/cta.service.js
+++ b/chicagoCTA/cta.service.js
@@ -14,10 +14,10 @@ angular.module('mirror')
         }).then(function successCallback(response) {
           for (var member in CTA.arrivals) delete CTA.arrivals[member];
           for (let arrival of response.data) {
-            if (!CTA.arrivals[arrival.stopDescription]) {
-              CTA.arrivals[arrival.stopDescription] = []
-         }
-            CTA.arrivals[arrival.stopDescription].push(arrival);
+            if (!CTA.arrivals[arrival.route + arrival.terminalDestinationName]) {
+              CTA.arrivals[arrival.route + arrival.terminalDestinationName] = []
+            }
+            CTA.arrivals[arrival.route + arrival.terminalDestinationName].push(arrival);
           }
           $log.debug("Refreshed CTA arrivals", CTA.arrivals);
         });


### PR DESCRIPTION
The arrivals are grouped together by which line and direction the
train is going. The brown and purple line use the same destination
(weirdly), so they would alternate overwrite each other in the list
of arrivals.
