### PR TITLE
Drop X-Triggr-Internal header, ditch old reason sober code

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -27,7 +27,8 @@ module.exports = {
     "Go kick some ass today!"
   ],
   TRIGGR_API_URL: 'http://localhost:1337/api/v1',
-  TRIGGR_API_KEY: '',
+  TRIGGR_USERNAME: '',
+  TRIGGR_PASSWORD: '',
   LAYOUT: {
     topLeft: [
       "clock-simple",


### PR DESCRIPTION
The header no longer works, so use real login methods.
The old filtering code was a work around for an API bug.