### PR TITLE
Update reason sober URL.

### DIFF
--- a/reasonSober/index.js
+++ b/reasonSober/index.js
@@ -15,7 +15,7 @@ const updateReasonSober = function(callback) {
   }
   request(options, (error, response, body) => {
     let reasonSoberOptions = {
-      url: config.TRIGGR_API_URL + '/reasonSober?status=approved',
+      url: config.TRIGGR_API_URL + '/superUser/reasonSober',
     };
 
     console.log('Updating reason sober', reasonSoberOptions);


### PR DESCRIPTION
New endpoint added in https://github.com/triggr/triggr_api/pull/864, https://github.com/triggr/triggr_api/pull/874/commits/ea46e48b4d8a68f760836e52af27f2e259adeaba does `status=approved` by default for reasonSober users.

Old endpoint will be removed in https://github.com/triggr/triggr_api/pull/875